### PR TITLE
Tidy up the Ruby Gems actions

### DIFF
--- a/.github/workflows/gempush.yml
+++ b/.github/workflows/gempush.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem
+name: Ruby Gems
 
 on:
   push:
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Set up Ruby 2.6
-      uses: actions/setup-ruby@v1
+      uses: actions/setup-ruby@master
       with:
         version: 2.6.x
 


### PR DESCRIPTION
Change the name and use the master branch of the setup-ruby action.