### PR TITLE
List assets explicitly

### DIFF
--- a/lib/dxw_govuk_frontend_rails.rb
+++ b/lib/dxw_govuk_frontend_rails.rb
@@ -5,7 +5,18 @@ module DxwGovukFrontendRails
     class Engine < ::Rails::Engine
       initializer 'GovukFrontendRails.assets.precompile' do |app|
         app.config.assets.precompile <<
-          /[\w]+\.(?:png|svg|gif|ico|eot|woff|woff2)$/
+          [
+            "favicon.ico",
+            "govuk-apple-touch-icon-152x152.png",
+            "govuk-apple-touch-icon-167x167.png",
+            "govuk-apple-touch-icon-180x180.png",
+            "govuk-apple-touch-icon.png",
+            "govuk-crest-2x.png",
+            "govuk-crest.png",
+            "govuk-logotype-crown.png",
+            "govuk-mask-icon.svg",
+            "govuk-opengraph-image.png",
+          ]
       end
     end
   end


### PR DESCRIPTION
Sprockets 4 does not support passing a regex to assets.precompile so we are
listing each asset in the array.

Assets included from the sass do not need to be added to the precompile list as
they get included by defalut. Fonts for example are loaded via the sass.